### PR TITLE
Daiki

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -112,21 +112,32 @@ footer {
 .side_genres {
 	font-size: 18px;
 	width: 200px;
-}
-
-.side_genres_tb {
-	border: medium solid #999;
+	padding: 0.2em 0.5em;
+	margin: 2em 0;
+	color: #565656;
+	background: #ffeaea;
+	box-shadow: 0px 0px 0px 10px #ffeaea;
+	border: dashed 2px #ffc3c3;
+	border-radius: 8px;
 }
 
 .side_genres_head {
-	background-color: #ccc;
-	border-bottom: medium solid #999;
+	border-bottom: dashed 2px #ffc3c3;
 	text-align: center;
 }
 
+.side_genres_items {
+	padding-left: 20px;
+}
+
 .side_genres_words {
-	color: #000;
+	color: #666;
 	line-height: 200%;
+	padding-left: 8px;
+}
+
+.side_ico {
+	font-size: 12px;
 }
 
 //public/top
@@ -161,4 +172,32 @@ footer {
 
 .empty_align {
 	margin-top: 5px;
+}
+
+.pb_products_list {
+	position: relative;
+	background: #fff0cd;
+	box-shadow: 0px 0px 0px 5px #fff0cd;
+	border: dashed 2px white;
+	padding: 0.2em 0.5em;
+	color: #454545;
+	width: 180px;
+	height: 200px;
+	margin: 10px 10px;
+}
+
+.pb_products_list:after {
+	position: absolute;
+	content: '';
+	right: -7px;
+	top: -7px;
+	border-width: 0 15px 15px 0;
+	border-style: solid;
+	border-color: #ffdb88 #fff #ffdb88;
+	box-shadow: -1px 1px 1px rgba(0, 0, 0, 0.15);
+}
+
+.under_bar {
+	margin: 20px auto;
+	border-top: 2px solid #666;
 }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -201,3 +201,28 @@ footer {
 	margin: 20px auto;
 	border-top: 2px solid #666;
 }
+
+.products_show_item {
+	position: relative;
+	background: #fff0cd;
+	box-shadow: 0px 0px 0px 5px #fff0cd;
+	border: dashed 2px white;
+	padding: 0.2em 0.5em;
+	color: #454545;
+	margin: 10px 10px;
+}
+
+.products_show_item:after {
+	position: absolute;
+	content: '';
+	right: -7px;
+	top: -7px;
+	border-width: 0 15px 15px 0;
+	border-style: solid;
+	border-color: #ffdb88 #fff #ffdb88;
+	box-shadow: -1px 1px 1px rgba(0, 0, 0, 0.15);
+}
+
+.product_intro {
+	height: 80px;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -90,6 +90,10 @@ footer {
 	font-size: 18px;
 }
 
+.customer_login_button {
+	padding: 8px 40px;
+}
+
 .new_customer_text_config {
 	line-height: 25px;
 }

--- a/app/controllers/public/products_controller.rb
+++ b/app/controllers/public/products_controller.rb
@@ -2,8 +2,14 @@ class Public::ProductsController < ApplicationController
 
 	def index
 		@genres = Genre.where.not(is_active: "false")
-		@products = Product.where.not(status: "false").page(params[:page]).per(8)
-		@pdcount = Product.all
+
+		if params[:para].present?
+			@products = Product.where(genre_id: params[:para], status: "true").page(params[:page]).per(8)
+			@genre = @products.first.genre
+		else
+			@products = Product.where.not(status: "false").page(params[:page]).per(8)
+			@pdcount = Product.all
+		end
 	end
 
 	def show
@@ -17,4 +23,8 @@ class Public::ProductsController < ApplicationController
 		@genres = Genre.all.where.not(is_active: "false")
 		@products = Product.where.not(status: "false").shuffle.take(4)
 	end
+
+	# def search
+	# 	@products = Product.search(params[:search])
+	# end
 end

--- a/app/views/customers/registrations/new.html.erb
+++ b/app/views/customers/registrations/new.html.erb
@@ -41,7 +41,7 @@
 
       <div class="row customer_font_sizing">
         <p class="col-xs-4">電話番号(ハイフンなし)</p>
-        <div class="col-xs-8"><%= f.text_field :phone_number, :placeholder => "090123456" %></div>
+        <div class="col-xs-8"><%= f.text_field :phone_number, :placeholder => "09012345678" %></div>
       </div>
 
       <div class="row customer_font_sizing">

--- a/app/views/customers/registrations/new.html.erb
+++ b/app/views/customers/registrations/new.html.erb
@@ -41,12 +41,12 @@
 
       <div class="row customer_font_sizing">
         <p class="col-xs-4">電話番号(ハイフンなし)</p>
-        <div class="col-xs-8"><%= f.text_field :phone_number %></div>
+        <div class="col-xs-8"><%= f.text_field :phone_number, :placeholder => "090123456" %></div>
       </div>
 
       <div class="row customer_font_sizing">
         <p class="col-xs-4">パスワード(6文字以上)</p>
-        <div class="col-xs-8"><%= f.password_field :password, autocomplete: "new-password" %></div>
+        <div class="col-xs-8"><%= f.password_field :password, autocomplete: "new-password", :placeholder => "6文字以上" %></div>
       </div>
 
       <div class="row customer_font_sizing">

--- a/app/views/customers/sessions/new.html.erb
+++ b/app/views/customers/sessions/new.html.erb
@@ -1,5 +1,5 @@
 <div class="row ">
-  <div class="col-xs-2">
+  <div class="col-xs-1">
   </div>
   <div class="col-xs-9">
     <div class="row">
@@ -8,17 +8,17 @@
     <div class="row">　</div>
     <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
       <div class="row">
-        <div class="col-xs-2">
+        <div class="col-xs-1">
         </div>
         <div class="col-xs-3">
           <%= f.label "メールアドレス" %>
         </div>
-        <%= f.email_field :email, autofocus:true, autocomplete: "email", class: "col-xs-5" %>
+        <%= f.email_field :email, autofocus:true, autocomplete: "email", class: "col-xs-5", :placeholder => "yamada@example.com" %>
       </div>
       <div class="row">　</div>
 
       <div class="row">
-        <div class="col-xs-2">
+        <div class="col-xs-1">
         </div>
         <div class="col-xs-3">
           <%= f.label "パスワード" %>
@@ -26,21 +26,36 @@
         <%= f.password_field :password, autocomplete: "current-password", class: "col-xs-5" %>
       </div>
       <div class="row">
-        <div class="col-xs-2"></div>
-        <div class="col-xs-10">
-          <% if devise_mapping.rememberable? %>
-            <div class="field">
-              <%= f.check_box :remember_me %>
-              <%= f.label :remember_me %>
-            </div>
+        <div class="col-xs-6"></div>
+        <div class="col-xs-4">
+          <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+            <%= link_to "=> パスワードを忘れた方はコチラ", new_password_path(resource_name) %><br />
           <% end %>
         </div>
         <div class="row actions">
-          <%= f.submit "Log in", class: "btn btn-success"%>
+          <div class="col-xs-4"></div>
+          <div class="col-xs-2">
+            <%= f.submit "ログイン", class: "btn btn-success customer_login_button"%>
+          </div>
         </div>
+
+        <div class="row">
+          <div class="col-xs-1"></div>
+          <div class="col-xs-4">
+            <h3>登録がお済みでない方</h3>
+          </div>
+        </div>
+        <div class="row empty_align">　</div>
+        <div class="row">
+          <div class="col-xs-3"></div>
+          <div class="col-xs-4">
+            <p><%= link_to "こちら",new_customer_registration_path %>　から新規登録を行ってください。
+          </div>
+        </div>
+
       </div>
     <% end %>
   </div>
 </div>
 
-<%= render "customers/shared/links" %>
+

--- a/app/views/customers/shared/_links.html.erb
+++ b/app/views/customers/shared/_links.html.erb
@@ -7,7 +7,7 @@
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+  <%= link_to "パスワードを忘れた方はコチラ", new_password_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>

--- a/app/views/public/products/_side_genre.html.erb
+++ b/app/views/public/products/_side_genre.html.erb
@@ -6,7 +6,7 @@
 		<tr>
 			<td class="side_genres_items">
 				<% @genres.each do |genre| %>
-				<%= link_to genre.name, public_products_path, class: "side_genres_words"%>
+				<%= link_to genre.name, public_products_path, class: "side_genres_words" %>
 				<br>
 				<% end %>
 			</td>

--- a/app/views/public/products/_side_genre.html.erb
+++ b/app/views/public/products/_side_genre.html.erb
@@ -6,7 +6,7 @@
 		<tr>
 			<td class="side_genres_items">
 				<% @genres.each do |genre| %>
-				<%= link_to genre.name, public_products_path, class: "side_genres_words" %>
+				<%= link_to genre.name, public_products_path(:para => genre.id), class: "side_genres_words" %>
 				<br>
 				<% end %>
 			</td>

--- a/app/views/public/products/_side_genre.html.erb
+++ b/app/views/public/products/_side_genre.html.erb
@@ -6,7 +6,7 @@
 		<tr>
 			<td class="side_genres_items">
 				<% @genres.each do |genre| %>
-				<%= link_to genre.name, public_products_path(:para => genre.id), class: "side_genres_words" %>
+					<span class="glyphicon glyphicon-tag side_ico"></span><%= link_to genre.name, public_products_path(:para => genre.id), class: "side_genres_words" %>
 				<br>
 				<% end %>
 			</td>

--- a/app/views/public/products/index.html.erb
+++ b/app/views/public/products/index.html.erb
@@ -12,9 +12,10 @@
 				<% end %>
 			</h2>
 			<div class="row empty_align">　</div>
+			<div class="row">
 				<% @products.each do |product| %>
 					<div class="pb_products_list col-xs-3">
-						<div><%= attachment_image_tag product, :image, :fill, 200, 150, format: "jpg" %></div>
+						<div><%= attachment_image_tag product, :image, :fill, 160, 140, format: "jpg" %></div>
 						<div><%=link_to public_product_path(product.id) do %>
 								<P><%= product.name %></P>
 							 <% end %>
@@ -23,7 +24,7 @@
 					</div>
 				<% end %>
 			</div>
-			<div class="row">
+			<div class="row under_bar">
 				<div class="col-xs-2"></div>
 				<div class="col-xs-3">
 					<%= paginate @products %>

--- a/app/views/public/products/index.html.erb
+++ b/app/views/public/products/index.html.erb
@@ -5,12 +5,13 @@
 		</div>
 		<div class="col-xs-9">
 			<h2 class="row">
-				<% if @genre.nil? %>
-					商品一覧(全<%= @pdcount.count %>件)
+				<% if @genre.present? %>
+					<%= @genre.name %>一覧(全<%= @products.count %>件)
 				<% else %>
-					<%= @genre.name %>一覧(全<%= @product.count %>件)
+					商品一覧(全<%= @pdcount.count %>件)
 				<% end %>
 			</h2>
+			<div class="row empty_align">　</div>
 				<% @products.each do |product| %>
 					<div class="pb_products_list col-xs-3">
 						<div><%= attachment_image_tag product, :image, :fill, 200, 150, format: "jpg" %></div>
@@ -21,8 +22,13 @@
 						<div>￥<%= product.price %></div>
 					</div>
 				<% end %>
+			</div>
+			<div class="row">
+				<div class="col-xs-2"></div>
+				<div class="col-xs-3">
+					<%= paginate @products %>
+				</div>
 
-				<%= paginate @products %>
 			</div>
 		</div>
 	</div>

--- a/app/views/public/products/index.html.erb
+++ b/app/views/public/products/index.html.erb
@@ -4,9 +4,15 @@
 			<%= render 'side_genre' %>
 		</div>
 		<div class="col-xs-9">
-			<h2 class="row">商品一覧(全<%= @pdcount.count %>件)</h2>
+			<h2 class="row">
+				<% if @genre.nil? %>
+					商品一覧(全<%= @pdcount.count %>件)
+				<% else %>
+					<%= @genre.name %>一覧(全<%= @product.count %>件)
+				<% end %>
+			</h2>
 				<% @products.each do |product| %>
-					<div class="pb_products_list col-xs-4">
+					<div class="pb_products_list col-xs-3">
 						<div><%= attachment_image_tag product, :image, :fill, 200, 150, format: "jpg" %></div>
 						<div><%=link_to public_product_path(product.id) do %>
 								<P><%= product.name %></P>

--- a/app/views/public/products/show.html.erb
+++ b/app/views/public/products/show.html.erb
@@ -6,14 +6,14 @@
 
 	<div class="col-xs-9">
 		<div class="row">
-			<div class="col-xs-5">
-				<%= attachment_image_tag @product, :image, :fill, 300, 200, format: "jpg" %>
+			<div class="col-xs-4 products_show_item">
+				<%= attachment_image_tag @product, :image, :fill, 240, 200, format: "jpg" %>
 			</div>
 
-			<div class="col-xs-7">
+			<div class="col-xs-5 products_show_item">
 				<h2><b><%= @product.name %></b></h2>
-				<div><%= @product.explain %></div>
-				<h3><b>￥<%= (@product.price * 1.08).ceil %><span class="public_price_font_size">(税込)</span></b></h3>
+				<div class="product_intro"><%= @product.explain %></div>
+				<h3><b>￥<%= (@product.price * 1.08).to_i %><span class="public_price_font_size">(税込)</span></b></h3>
 			</div>
 		</div>
 		<div>　　　</div>


### PR DESCRIPTION
## 更新内容は以下の通りです。
### 商品一覧画面
・ジャンル名を押すと、ジャンルの物のみ表示されるようになりました。
　ジャンル一覧のlink_toから、[:para]という変数にgenre_idを受け渡し、contorollerに引き渡した後、whereでgenre_idと販売ステータスが適している商品のみ表示されるようにしました。

・ジャンル一覧になっているときに「ジャンル名一覧」で表示されるように変更しました。
・付箋風のデザインを採用し、お菓子屋さんっぽいイメージにしてみました。(CSS)

### ジャンル
・刺繡っぽいイメージでデザインしてみました。
・文字の間隔、アイコンの追加等修正しました。

### 商品詳細画面
・商品価格が小数点切り上げだったので.to_iに変更しました。
・商品説明が短いとき、価格が上に移動してしまうので、説明にheightを設定しました。
・デザインは一覧画面から流用しました。
【以前の記入漏れ】（・ログインしていない場合にカート投入ボタンを設置せず、登録・ログインを促す文を表示するように変更しました。）